### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "Text::Spintax",
+    "license" : "Artistic-2.0",
     "version" : "0.01",
     "description" : "A parser and renderer for spintax formatted text",
     "authors" : ["Dale Evans"],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license